### PR TITLE
fix error AbstractTransport:: must not be accessed before initialization

### DIFF
--- a/src/ElasticTransport.php
+++ b/src/ElasticTransport.php
@@ -17,6 +17,8 @@ class ElasticTransport extends AbstractTransport
 
     public function __construct($key)
     {
+        parent::__construct();
+
         $this->key = $key;
     }
 


### PR DESCRIPTION
Hello,
I had an error and fixed it.

"message": "Typed property Symfony\\Component\\Mailer\\Transport\\AbstractTransport::$dispatcher must not be accessed before initialization",

please see this page

https://laravel.com/docs/9.x/mail#custom-transports