### PR TITLE
Fixed attachedFilePath location

### DIFF
--- a/src/ElasticTransport.php
+++ b/src/ElasticTransport.php
@@ -96,7 +96,7 @@ class ElasticTransport extends AbstractTransport
                     $tempName = uniqid().'.'.$ext;
                     Storage::put($tempName, $attachedFile);
                     $type = $attachment->getMediaType().'/'.$attachment->getMediaSubtype();
-                    $attachedFilePath = storage_path($tempName);
+                    $attachedFilePath = Storage::path($tempName);
                     $data['file_'.$i] = new \CurlFile($attachedFilePath, $type, $fileName);
                     $i++;
                 }


### PR DESCRIPTION
storage_path() in Laravel returns the absolute path to the storage directory (usually /storage), not the driver-specific root path where Laravel's Storage facade typically stores files. If Storage::put() is used to store the file, the file path should be revealed with Storage::path() otherwise the file may be stored in storage/app/file.txt but the attachedFilePath is /storage/file.txt