### PR TITLE
Fixed the absolute local path issue in mail attachments

### DIFF
--- a/src/ElasticTransport.php
+++ b/src/ElasticTransport.php
@@ -94,9 +94,9 @@ class ElasticTransport extends AbstractTransport
                     $fileName = $attachment->getPreparedHeaders()->getHeaderParameter('Content-Disposition', 'filename');
                     $ext = pathinfo($fileName, PATHINFO_EXTENSION);
                     $tempName = uniqid().'.'.$ext;
-                    Storage::put($tempName, $attachedFile);
+                    Storage::drive("local")->put($tempName, $attachedFile);
                     $type = $attachment->getMediaType().'/'.$attachment->getMediaSubtype();
-                    $attachedFilePath = storage_path($tempName);
+                    $attachedFilePath = Storage::drive("local")->path($tempName);
                     $data['file_'.$i] = new \CurlFile($attachedFilePath, $type, $fileName);
                     $i++;
                 }


### PR DESCRIPTION
It is good to specify the driver for which we are creating the file `Storage::driver('local')`, If someone has changed the default file system driver to another driver other than the 'local', then that someone will have conflicts.